### PR TITLE
[Fix]: doesn't search when there is no PATH

### DIFF
--- a/cmd_exec.c
+++ b/cmd_exec.c
@@ -65,10 +65,10 @@ char *_which(char *cmd, char **_environ)
 			token_path = _strtok(NULL, ":");
 		}
 		free(ptr_path);
-	}
 
 	if (stat(cmd, &st) == 0)
 		return (cmd);
+	}
 
 	return (NULL);
 }


### PR DESCRIPTION
Modified: cmd_exec.c